### PR TITLE
Header Keyの大文字小文字がDocumentと異なるので、ちゃんとどっちでも大丈夫にした

### DIFF
--- a/cloudtasks/appengine/header.go
+++ b/cloudtasks/appengine/header.go
@@ -84,57 +84,57 @@ type Header struct {
 func GetHeader(r *http.Request) (*Header, error) {
 	var ret Header
 
-	v, ok := r.Header[AppEngineTaskName]
-	if ok {
-		ret.TaskName = v[0]
+	v := r.Header.Get(AppEngineTaskName)
+	if len(v) > 0 {
+		ret.TaskName = v
 	} else {
 		return nil, ErrNotFoundHeader
 	}
 
-	v, ok = r.Header[AppEngineQueueName]
-	if ok {
-		ret.QueueName = v[0]
+	v = r.Header.Get(AppEngineQueueName)
+	if len(v) > 0 {
+		ret.QueueName = v
 	}
 
-	v, ok = r.Header[AppEngineTaskRetryCount]
-	if ok {
-		i, err := strconv.ParseInt(v[0], 10, 64)
+	v = r.Header.Get(AppEngineTaskRetryCount)
+	if len(v) > 0 {
+		i, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s. v=%v", AppEngineTaskRetryCount, v)
 		}
 		ret.TaskRetryCount = i
 	}
 
-	v, ok = r.Header[AppEngineTaskExecutionCount]
-	if ok {
-		i, err := strconv.ParseInt(v[0], 10, 64)
+	v = r.Header.Get(AppEngineTaskExecutionCount)
+	if len(v) > 0 {
+		i, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s. v=%v", AppEngineTaskExecutionCount, v)
 		}
 		ret.TaskExecutionCount = i
 	}
 
-	v, ok = r.Header[AppEngineTaskETA]
-	if ok {
-		i, err := strconv.ParseInt(v[0], 10, 64)
+	v = r.Header.Get(AppEngineTaskETA)
+	if len(v) > 0 {
+		i, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid %s. v=%v", AppEngineTaskETA, v)
 		}
 		ret.TaskETA = time.Unix(i, 0)
 	}
 
-	v, ok = r.Header[AppEngineTaskPreviousResponse]
-	if ok {
-		ret.TaskPreviousResponse = v[0]
+	v = r.Header.Get(AppEngineTaskPreviousResponse)
+	if len(v) > 0 {
+		ret.TaskPreviousResponse = v
 	}
 
-	v, ok = r.Header[AppEngineTaskRetryReason]
-	if ok {
-		ret.TaskRetryReason = v[0]
+	v = r.Header.Get(AppEngineTaskRetryReason)
+	if len(v) > 0 {
+		ret.TaskRetryReason = v
 	}
 
-	v, ok = r.Header[AppEngineFailFast]
-	if ok {
+	v = r.Header.Get(AppEngineFailFast)
+	if len(v) > 0 {
 		ret.FailFast = true
 	}
 

--- a/cloudtasks/appengine/header_test.go
+++ b/cloudtasks/appengine/header_test.go
@@ -1,0 +1,19 @@
+package appengine
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestGetHeader(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/hoge", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Header.Set("X-Appengine-Taskname", "hoge")
+
+	_, err = GetHeader(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
https://cloud.google.com/tasks/docs/creating-appengine-handlers?hl=en#reading_app_engine_task_request_headers には `X-CloudTasks-TaskName` みたいな形式で書いてあるけど、実際には `X-CloudTasks-Taskname` のように先頭だけが大文字で来る。