### PR TITLE
ContextにUserを保持する実装を追加

### DIFF
--- a/iap/appengine/user.go
+++ b/iap/appengine/user.go
@@ -1,0 +1,74 @@
+package appengine
+
+import (
+	"context"
+	"errors"
+	"net/http"
+)
+
+const (
+	// UserIDKey is App Engine User ID Header Key
+	UserIDKey = "X-Appengine-User-Id"
+
+	// UserEmailKey is App Engine User Email Header Key
+	UserEmailKey = "X-Appengine-User-Email"
+
+	// UserNicknameKey is App Engine User Nickname Header Key
+	UserNicknameKey = "X-Appengine-User-Nickname"
+
+	// UserIsAdminKey is App Engine User Is Admin Key
+	UserIsAdminKey = "X-Appengine-User-Is-Admin"
+)
+
+type contextUser struct{}
+
+// ErrNotLogin is Loginしてない時に返す
+var ErrNotLogin = errors.New("not login")
+
+// User is IAPを通してログインしているUser
+// App Engine 用
+//
+// note: Every user has the same user ID for all App Engine applications.
+// If your app uses the user ID in public data, such as by including it in a URL parameter, you should use a hash algorithm with a "salt" value added to obscure the ID.
+// Exposing raw IDs could allow someone to associate a user's activity in one app with that in another, or get the user's email address by coercing the user to sign in to another app.
+type User struct {
+	ID       string
+	Email    string
+	Nickname string
+	Admin    bool
+}
+
+// GetUser is IAPを通してログインしているUserを取得する
+func GetUser(r *http.Request) (*User, error) {
+	id := r.Header.Get(UserIDKey)
+	email := r.Header.Get(UserEmailKey)
+	nickname := r.Header.Get(UserNicknameKey)
+	isAdmin := r.Header.Get(UserIsAdminKey)
+
+	if id == "" {
+		return nil, ErrNotLogin
+	}
+
+	return &User{
+		ID:       id,
+		Email:    email,
+		Nickname: nickname,
+		Admin:    (isAdmin == "1"),
+	}, nil
+}
+
+// WithContextValue is context に user をセットする
+func WithContextValue(ctx context.Context, user *User) context.Context {
+	return context.WithValue(ctx, contextUser{}, user)
+}
+
+// CurrentUser is context からUserを取得する
+//
+// 先に WithContextValue() でセットされていることが前提
+func CurrentUser(ctx context.Context) (*User, bool) {
+	user, ok := ctx.Value(contextUser{}).(*User)
+	if ok {
+		return user, true
+	}
+	return nil, false
+}

--- a/iap/appengine/user_test.go
+++ b/iap/appengine/user_test.go
@@ -1,0 +1,94 @@
+package appengine_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	iapbox "github.com/sinmetal/gcpbox/iap/appengine"
+)
+
+func TestGetUser(t *testing.T) {
+	cases := []struct {
+		name      string
+		admin     string
+		wantAdmin bool
+	}{
+		{"admin", "1", true},
+		{"non-admin", "0", false},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := http.NewRequest(http.MethodGet, "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			const id = "11111"
+			const email = "sinmetal@sinmetalcraft.jp"
+			const nickname = "sinmetal"
+			r.Header.Set(iapbox.UserIDKey, id)
+			r.Header.Set(iapbox.UserEmailKey, email)
+			r.Header.Set(iapbox.UserNicknameKey, nickname)
+			r.Header.Set(iapbox.UserIsAdminKey, tt.admin)
+
+			u, err := iapbox.GetUser(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if e, g := id, u.ID; e != g {
+				t.Errorf("id want %v but got %v", e, g)
+			}
+			if e, g := email, u.Email; e != g {
+				t.Errorf("email want %v but got %v", e, g)
+			}
+			if e, g := nickname, u.Nickname; e != g {
+				t.Errorf("nickname want %v but got %v", e, g)
+			}
+			if e, g := tt.wantAdmin, u.Admin; e != g {
+				t.Errorf("admin want %v but got %v", e, g)
+			}
+		})
+	}
+}
+
+func TestGetUserNotLogin(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = iapbox.GetUser(r)
+	if err != iapbox.ErrNotLogin {
+		t.Errorf("got err is %v", err)
+	}
+}
+
+func TestWithContextValue(t *testing.T) {
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const id = "11111"
+	const email = "sinmetal@sinmetalcraft.jp"
+	const nickname = "sinmetal"
+	r.Header.Set(iapbox.UserIDKey, id)
+	r.Header.Set(iapbox.UserEmailKey, email)
+	r.Header.Set(iapbox.UserNicknameKey, nickname)
+	r.Header.Set(iapbox.UserIsAdminKey, "1")
+
+	u, err := iapbox.GetUser(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := iapbox.WithContextValue(context.Background(), u)
+	got, ok := iapbox.CurrentUser(ctx)
+	if !ok {
+		t.Errorf("user not found")
+	}
+	if e, g := id, got.ID; e != g {
+		t.Errorf("id want %v but got %v", e, g)
+	}
+}


### PR DESCRIPTION
* appengine user serviceがそんな実装が入ってたので、同じようなノリで使えるようにした。
* functionが増えてきて、サジェストが多くなってきたので、appengineとそれ以外でごりっとpackageを分けた。