### PR TITLE
BigQuery Streaming Insertを100件ずつ並列に行うように修正した

### DIFF
--- a/bigquery/streaming_insert.go
+++ b/bigquery/streaming_insert.go
@@ -1,0 +1,60 @@
+package bigquery
+
+import (
+	"context"
+	"sync"
+
+	"cloud.google.com/go/bigquery"
+	errbox "github.com/sinmetal/gcpbox/errors"
+)
+
+type BigQueryService struct {
+	BQ *bigquery.Client
+}
+
+func NewBigQueryService(bq *bigquery.Client) (*BigQueryService, error) {
+	return &BigQueryService{
+		bq,
+	}, nil
+}
+
+func (s *BigQueryService) Close() error {
+	if s.BQ != nil {
+		return s.BQ.Close()
+	}
+	return nil
+}
+
+// InsertStructSaverToBigQuery is StructSaverをBigQueryにStreamingInsertでInsertする
+// InsertはAtomicには行われない。 Error時は StreamingInsertErrors を返す。
+func (s *BigQueryService) Insert(ctx context.Context, dataset *bigquery.Dataset, table string, sss []*bigquery.StructSaver) error {
+	if len(sss) < 101 {
+		if err := s.BQ.DatasetInProject(dataset.ProjectID, dataset.DatasetID).Table(table).Inserter().Put(ctx, sss); err != nil {
+			return err
+		}
+	}
+
+	const size = 100
+	errResult := &errbox.BigQueryStreamingInsertErrors{}
+	wg := &sync.WaitGroup{}
+	for i := 0; i < len(sss); i += size {
+		end := i + size
+		if len(sss) < end {
+			end = len(sss)
+		}
+		wg.Add(1)
+		go func(list []*bigquery.StructSaver) {
+			defer wg.Done()
+			if err := s.BQ.DatasetInProject(dataset.ProjectID, dataset.DatasetID).Table(table).Inserter().Put(ctx, list); err != nil {
+				for _, v := range list {
+					errResult.Append(&errbox.BigQueryStreamingInsertError{
+						InsertID: v.InsertID,
+						Err:      err,
+					})
+				}
+			}
+		}(sss[i:end])
+	}
+	wg.Wait()
+	return errResult.ErrorOrNil()
+}

--- a/bigquery/streaming_insert_test.go
+++ b/bigquery/streaming_insert_test.go
@@ -1,0 +1,71 @@
+package bigquery_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+
+	. "github.com/sinmetal/gcpbox/bigquery"
+)
+
+var SampleTableSchema = bigquery.Schema{
+	{Name: "Text", Required: true, Type: bigquery.StringFieldType},
+	{Name: "Count", Required: true, Type: bigquery.IntegerFieldType},
+}
+
+type Sample struct {
+	Text  string
+	Count int64
+}
+
+func TestBigQueryService_Insert(t *testing.T) {
+	ctx := context.Background()
+
+	s := newBigQueryService(t)
+
+	dataset := &bigquery.Dataset{ProjectID: "sinmetal-ci", DatasetID: "bqbox"}
+	table := fmt.Sprintf("insert_%d", time.Now().Unix())
+	err := s.BQ.Dataset(dataset.DatasetID).Table(table).Create(ctx, &bigquery.TableMetadata{
+		Name:   table,
+		Schema: SampleTableSchema,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txt := time.Now().String()
+	var sss []*bigquery.StructSaver
+	for i := 0; i < 30001; i++ {
+		sss = append(sss, &bigquery.StructSaver{
+			InsertID: fmt.Sprintf("%v", i),
+			Schema:   SampleTableSchema,
+			Struct: &Sample{
+				Text:  txt,
+				Count: int64(i),
+			},
+		})
+	}
+
+	if err := s.Insert(ctx, dataset, table, sss); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newBigQueryService(t *testing.T) *BigQueryService {
+	ctx := context.Background()
+	const projectID = "sinmetal-ci"
+
+	bqClient, err := bigquery.NewClient(ctx, projectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := NewBigQueryService(bqClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: gcr.io/cloud-builders/docker
     id: spanner-emulator
-    args: ['run', '-d', '-p' '9010:9010' '-p' '9020:9020', '--network=cloudbuild', '--name=spanner-emulator', 'gcr.io/cloud-spanner-emulator/emulator:0.8.0']
+    args: ['run', '-d', '-p', '9010:9010', '-p', '9020:9020', '--network=cloudbuild', '--name=spanner-emulator', 'gcr.io/cloud-spanner-emulator/emulator:0.8.0']
   - name: jwilder/dockerize:0.6.1
     args: ['dockerize', '-timeout=60s', '-wait=tcp://spanner-emulator:9010']
   - name: 'golang:1.14-stretch'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,12 @@
 steps:
   - name: gcr.io/cloud-builders/docker
+    id: cds-emulator
+    args: ['run', '-d', '--network=cloudbuild', '--name=cds-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'beta', 'emulators', 'datastore', 'start', '--host-port=0.0.0.0:8081']
+  - name: gcr.io/cloud-builders/docker
     id: spanner-emulator
     args: ['run', '-d', '--network=cloudbuild', '--name=spanner-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'beta', 'emulators', 'spanner', 'start', '--host-port=0.0.0.0:9010']
+  - name: jwilder/dockerize:0.6.1
+    args: ['dockerize', '-timeout=60s', '-wait=tcp://cds-emulator:8081']
   - name: 'golang:1.14-stretch'
     entrypoint: 'go'
     args: ['test', './...']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,5 +7,7 @@ steps:
   - name: 'golang:1.14-stretch'
     entrypoint: 'go'
     args: ['test', './...']
-    env: ['GO111MODULE=on', 'SPANNER_EMULATOR_HOST=localhost:9010']
+    env:
+      - 'GO111MODULE=on'
+      - 'SPANNER_EMULATOR_HOST=spanner-emulator:9010'
     waitFor: ['spanner-emulator']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: gcr.io/cloud-builders/docker
     id: spanner-emulator
-    args: ['run', '-d', '--network=cloudbuild', '--name=spanner-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'emulators', 'spanner', 'start', '--host-port=0.0.0.0:9010']
+    args: ['run', '-d', '--network=cloudbuild', '--name=spanner-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'beta', 'emulators', 'spanner', 'start', '--host-port=0.0.0.0:9010']
   - name: jwilder/dockerize:0.6.1
     args: ['dockerize', '-timeout=60s', '-wait=tcp://spanner-emulator:9010']
   - name: 'golang:1.14-stretch'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,8 +2,6 @@ steps:
   - name: gcr.io/cloud-builders/docker
     id: spanner-emulator
     args: ['run', '-d', '--network=cloudbuild', '--name=spanner-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'beta', 'emulators', 'spanner', 'start', '--host-port=0.0.0.0:9010']
-  - name: jwilder/dockerize:0.6.1
-    args: ['dockerize', '-timeout=60s', '-wait=tcp://spanner-emulator:9010']
   - name: 'golang:1.14-stretch'
     entrypoint: 'go'
     args: ['test', './...']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,11 @@
 steps:
-  - name: 'golang:1.13-stretch'
+  - name: gcr.io/cloud-builders/docker
+    id: spanner-emulator
+    args: ['run', '-d', '--network=cloudbuild', '--name=spanner-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'emulators', 'spanner', 'start', '--host-port=0.0.0.0:9010']
+  - name: jwilder/dockerize:0.6.1
+    args: ['dockerize', '-timeout=60s', '-wait=tcp://spanner-emulator:9010']
+  - name: 'golang:1.14-stretch'
     entrypoint: 'go'
     args: ['test', './...']
-    env: ['GO111MODULE=on']
+    env: ['GO111MODULE=on', 'SPANNER_EMULATOR_HOST=localhost:9010']
+    waitFor: ['spanner-emulator']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,12 +1,9 @@
 steps:
   - name: gcr.io/cloud-builders/docker
-    id: cds-emulator
-    args: ['run', '-d', '--network=cloudbuild', '--name=cds-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'beta', 'emulators', 'datastore', 'start', '--host-port=0.0.0.0:8081']
-  - name: gcr.io/cloud-builders/docker
     id: spanner-emulator
-    args: ['run', '-d', '--network=cloudbuild', '--name=spanner-emulator', 'google/cloud-sdk:302.0.0', 'gcloud', 'beta', 'emulators', 'spanner', 'start', '--host-port=0.0.0.0:9010']
+    args: ['run', '-d', '-p' '9010:9010' '-p' '9020:9020', '--network=cloudbuild', '--name=spanner-emulator', 'gcr.io/cloud-spanner-emulator/emulator:0.8.0']
   - name: jwilder/dockerize:0.6.1
-    args: ['dockerize', '-timeout=60s', '-wait=tcp://cds-emulator:8081']
+    args: ['dockerize', '-timeout=60s', '-wait=tcp://spanner-emulator:9010']
   - name: 'golang:1.14-stretch'
     entrypoint: 'go'
     args: ['test', './...']

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,48 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+var _ error = &BigQueryStreamingInsertErrors{}
+var _ error = &BigQueryStreamingInsertError{}
+
+type BigQueryStreamingInsertErrors struct {
+	mutex  *sync.Mutex
+	Errors []*BigQueryStreamingInsertError
+}
+
+func (e *BigQueryStreamingInsertErrors) Error() string {
+	builder := strings.Builder{}
+	for i, v := range e.Errors {
+		builder.WriteString(v.Error())
+		if i < len(e.Errors) {
+			builder.WriteString("\n")
+		}
+	}
+	return builder.String()
+}
+
+func (e *BigQueryStreamingInsertErrors) Append(err *BigQueryStreamingInsertError) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.Errors = append(e.Errors, err)
+}
+
+func (e *BigQueryStreamingInsertErrors) ErrorOrNil() error {
+	if len(e.Errors) > 0 {
+		return e
+	}
+	return nil
+}
+
+type BigQueryStreamingInsertError struct {
+	InsertID string
+	Err      error
+}
+
+func (e *BigQueryStreamingInsertError) Error() string {
+	return fmt.Errorf("InsertID:%s : %w", e.InsertID, e.Err).Error()
+}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,0 +1,59 @@
+package errors_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	errbox "github.com/sinmetal/gcpbox/errors"
+)
+
+func TestStreamingInsertError_Error(t *testing.T) {
+	org := &errbox.BigQueryStreamingInsertError{
+		InsertID: "sampleInsertID",
+		Err:      fmt.Errorf("hello sample error"),
+	}
+	var err error
+	err = org
+
+	var sierr *errbox.BigQueryStreamingInsertError
+	if !errors.As(err, &sierr) {
+		t.Error("err is not StreamingInsertError")
+	} else {
+		if e, g := org.InsertID, sierr.InsertID; e != g {
+			t.Errorf("want InsertID %v but got %v", e, g)
+		}
+	}
+}
+
+func TestStreamingInsertErrors_Error(t *testing.T) {
+	org1 := &errbox.BigQueryStreamingInsertError{
+		InsertID: "sampleInsertID1",
+		Err:      fmt.Errorf("hello sample error 1"),
+	}
+	org2 := &errbox.BigQueryStreamingInsertError{
+		InsertID: "sampleInsertID2",
+		Err:      fmt.Errorf("hello sample error 2"),
+	}
+
+	org := &errbox.BigQueryStreamingInsertErrors{}
+	org.Errors = append(org.Errors, org1, org2)
+
+	var err error
+	err = org
+
+	var sierr *errbox.BigQueryStreamingInsertErrors
+	if !errors.As(err, &sierr) {
+		t.Error("err is not StreamingInsertErrors")
+	} else {
+		if e, g := 2, len(sierr.Errors); e != g {
+			t.Errorf("want err.length %v but got %v", e, g)
+		}
+		errmsg := `InsertID:sampleInsertID1 : hello sample error 1
+InsertID:sampleInsertID2 : hello sample error 2
+`
+		if e, g := errmsg, sierr.Error(); e != g {
+			t.Errorf("want Error() %v but got %v", e, g)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	cloud.google.com/go/bigquery v1.8.0
 	cloud.google.com/go/spanner v1.6.0
 	cloud.google.com/go/storage v1.8.0
+	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
+	github.com/google/uuid v1.1.1
 	github.com/pkg/errors v0.9.1
 	google.golang.org/api v0.25.0
 	google.golang.org/genproto v0.0.0-20200526151428-9bb895338b15

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
+github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -98,6 +100,8 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,6 @@ cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bP
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0 h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
-cloud.google.com/go v0.58.0 h1:vtAfVc723K3xKq1BQydk/FyCldnaNFhGhpJxaJzgRMQ=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
@@ -275,8 +274,6 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88 h1:4j84u0sokprDu3IdSYHJMmou+YSLflMz8p7yAx/QI4g=
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200521211927-2b542361a4fc h1:6m2YO+AmBApbUOmhsghW+IfRyZOY4My4UYvQQrEpHfY=
-golang.org/x/tools v0.0.0-20200521211927-2b542361a4fc/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375 h1:SjQ2+AKWgZLc1xej6WSzL+Dfs5Uyd5xcZH1mGC411IA=
 golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/spanner/query_stats.go
+++ b/spanner/query_stats.go
@@ -96,7 +96,7 @@ func SplitDatabaseName(database string) (*Database, error) {
 }
 
 type QueryStat struct {
-	InsertID          string
+	InsertID          string    `spanner:"-"`
 	IntervalEnd       time.Time `spanner:"interval_end"` // End of the time interval that the included query executions occurred in.
 	Text              string    // SQL query text, truncated to approximately 64KB.
 	TextTruncated     bool      `spanner:"text_truncated"`      // Whether or not the query text was truncated.

--- a/spanner/query_stats_test.go
+++ b/spanner/query_stats_test.go
@@ -4,17 +4,42 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"cloud.google.com/go/spanner"
+	sadDatabase "cloud.google.com/go/spanner/admin/database/apiv1"
+	sadInstance "cloud.google.com/go/spanner/admin/instance/apiv1"
+	"github.com/dgryski/go-farm"
 	"google.golang.org/api/googleapi"
+	sdbproto "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+	protoInstance "google.golang.org/genproto/googleapis/spanner/admin/instance/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	. "github.com/sinmetal/gcpbox/spanner"
 )
 
 const (
-	projectID = "sinmetal-ci"
+	projectID                       = "sinmetal-ci"
+	queryStatsDummyTable            = "QUERY_STATS_DUMMY"
+	dummyQueryStatsTableCreateTable = `
+CREATE TABLE QUERY_STATS_DUMMY (
+    INTERVAL_END TIMESTAMP,
+    TEXT_FINGERPRINT INT64,
+    AVG_BYTES FLOAT64,
+    AVG_CPU_SECONDS FLOAT64,
+    AVG_LATENCY_SECONDS FLOAT64,
+    AVG_ROWS FLOAT64,
+    AVG_ROWS_SCANNED FLOAT64,
+    EXECUTION_COUNT INT64,
+    TEXT STRING(MAX),
+    TEXT_TRUNCATED BOOL,
+) PRIMARY KEY (INTERVAL_END DESC, TEXT_FINGERPRINT)`
 )
 
 func TestSplitDatabaseName(t *testing.T) {
@@ -59,8 +84,14 @@ func TestDatabase_ToSpannerDatabaseName(t *testing.T) {
 func TestQueryStatsCopyService_GetQueryStats(t *testing.T) {
 	ctx := context.Background()
 
-	s := newQueryStatsCopyService(t)
-	_, err := s.GetQueryStats(ctx, QueryStatsTopMinuteTable)
+	const project = "hoge"
+	const instance = "fuga"
+	database := fmt.Sprintf("test%d", rand.Intn(10000000))
+
+	newQueryStatsDummyData(t, project, instance, database)
+
+	s := newQueryStatsCopyService(t, project, instance, database)
+	_, err := s.GetQueryStats(ctx, queryStatsDummyTable)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +100,12 @@ func TestQueryStatsCopyService_GetQueryStats(t *testing.T) {
 func TestQueryStatsCopyService_Copy(t *testing.T) {
 	ctx := context.Background()
 
-	s := newQueryStatsCopyService(t)
+	const project = "hoge"
+	const instance = "fuga"
+	database := fmt.Sprintf("test%d", rand.Intn(10000000))
+	newSpannerDatabase(t, project, instance, fmt.Sprintf("CREATE DATABASE %s", database), []string{dummyQueryStatsTableCreateTable})
+
+	s := newQueryStatsCopyService(t, project, instance, database)
 
 	dataset := &bigquery.Dataset{ProjectID: projectID, DatasetID: "spanner_query_stats"}
 	table := "minutes"
@@ -85,7 +121,7 @@ func TestQueryStatsCopyService_Copy(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := s.Copy(ctx, dataset, table, QueryStatsTop10MinuteTable); err != nil {
+	if err := s.Copy(ctx, dataset, table, queryStatsDummyTable); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -93,11 +129,17 @@ func TestQueryStatsCopyService_Copy(t *testing.T) {
 func TestQueryStatsCopyService_Copy_TableCreate(t *testing.T) {
 	ctx := context.Background()
 
-	s := newQueryStatsCopyService(t)
+	const project = "hoge"
+	const instance = "fuga"
+	database := fmt.Sprintf("test%d", rand.Intn(10000000))
+
+	newSpannerDatabase(t, project, instance, fmt.Sprintf("CREATE DATABASE %s", database), []string{dummyQueryStatsTableCreateTable})
+
+	s := newQueryStatsCopyService(t, project, instance, database)
 
 	dataset := &bigquery.Dataset{ProjectID: projectID, DatasetID: "spanner_query_stats"}
 	table := "not_found"
-	if err := s.Copy(ctx, dataset, table, QueryStatsTop10MinuteTable); err != nil {
+	if err := s.Copy(ctx, dataset, table, queryStatsDummyTable); err != nil {
 		var ae *googleapi.Error
 		if ok := errors.As(err, &ae); ok {
 			if ae.Code == 404 {
@@ -113,11 +155,11 @@ func TestQueryStatsCopyService_Copy_TableCreate(t *testing.T) {
 	}
 }
 
-func newQueryStatsCopyService(t *testing.T) *QueryStatsCopyService {
+func newQueryStatsCopyService(t *testing.T, project string, instance string, database string) *QueryStatsCopyService {
 	ctx := context.Background()
 
 	spannerClient, err := spanner.NewClientWithConfig(ctx,
-		fmt.Sprintf("projects/%s/instances/%s/databases/%s", "gcpug-public-spanner", "merpay-sponsored-instance", "sinmetal"),
+		fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, database),
 		spanner.ClientConfig{
 			SessionPoolConfig: spanner.SessionPoolConfig{
 				MinOpened:     1,  // 基本的に同時に投げるのは 1 query
@@ -138,4 +180,116 @@ func newQueryStatsCopyService(t *testing.T) *QueryStatsCopyService {
 		t.Fatal(err)
 	}
 	return s
+}
+
+func newQueryStatsDummyData(t *testing.T, project string, instance string, database string) {
+	ctx := context.Background()
+
+	createStatement := fmt.Sprintf("CREATE DATABASE %s", database)
+	extraStatements := []string{
+		dummyQueryStatsTableCreateTable,
+	}
+	newSpannerDatabase(t, project, instance, createStatement, extraStatements)
+
+	sc, err := spanner.NewClientWithConfig(ctx, fmt.Sprintf("projects/%s/instances/%s/databases/%s", project, instance, database),
+		spanner.ClientConfig{
+			SessionPoolConfig: spanner.SessionPoolConfig{
+				MinOpened:     1,  // 1query投げておしまいので、1でOK
+				MaxOpened:     10, // 1query投げておしまいなので、そんなにたくさんは要らない
+				WriteSessions: 0,  // Readしかしないので、WriteSessionsをPoolする必要はない
+			},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		var mus []*spanner.Mutation
+		for j := 0; j < 30; j++ {
+			var list []string
+			for n := 0; n < 100000+rand.Intn(1000); n++ {
+				list = append(list, fmt.Sprintf("%d", n))
+			}
+			v := strings.Join(list, ",")
+			queryText := "SELECT " + v
+			stat := &QueryStat{
+				IntervalEnd:       time.Now(),
+				Text:              queryText,
+				TextTruncated:     false,
+				TextFingerprint:   int64(farm.Fingerprint64([]byte(queryText))),
+				ExecuteCount:      rand.Int63n(1000),
+				AvgLatencySeconds: rand.Float64(),
+				AvgRows:           rand.Float64(),
+				AvgBytes:          rand.Float64(),
+				AvgRowsScanned:    rand.Float64(),
+				AvgCPUSeconds:     rand.Float64(),
+			}
+			mu, err := spanner.InsertStruct("QUERY_STATS_DUMMY", stat)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mus = append(mus, mu)
+		}
+		_, err := sc.Apply(ctx, mus)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func newSpannerDatabase(t *testing.T, project string, instance string, createStatement string, extraStatements []string) {
+	seh := os.Getenv("SPANNER_EMULATOR_HOST")
+	if len(seh) < 1 {
+		t.Fatal("Required $SPANNER_EMULATOR_HOST")
+	}
+
+	ctx := context.Background()
+
+	spannerInstanceAdminClient, err := sadInstance.NewInstanceAdminClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := spannerInstanceAdminClient.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	spannerDatabaseAdminClient, err := sadDatabase.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := spannerDatabaseAdminClient.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	_, err = spannerInstanceAdminClient.CreateInstance(ctx, &protoInstance.CreateInstanceRequest{
+		Parent:     fmt.Sprintf("projects/%s", project),
+		InstanceId: instance,
+		Instance: &protoInstance.Instance{
+			Name:      fmt.Sprintf("projects/%s/instances/%s", project, instance),
+			NodeCount: 1,
+		},
+	})
+	if err != nil {
+		if status.Code(err) == codes.AlreadyExists {
+			// noop
+		} else {
+			t.Fatal(err)
+		}
+	}
+	_, err = spannerDatabaseAdminClient.CreateDatabase(ctx, &sdbproto.CreateDatabaseRequest{
+		Parent:          fmt.Sprintf("projects/%s/instances/%s", project, instance),
+		CreateStatement: createStatement,
+		ExtraStatements: extraStatements,
+	})
+	if err != nil {
+		if status.Code(err) == codes.AlreadyExists {
+			// noop
+		} else {
+			t.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
quotaに収まるように調整する。
per secondのsizeはあまり調整していない。

https://cloud.google.com/bigquery/quotas#streaming_inserts

* Maximum rows per second: 100,000
* Maximum bytes per second: 100 MB
* Maximum row size: 5 MB
* HTTP request size limit: 10 MB (see Note)
* Maximum rows per request: 10,000 rows per request